### PR TITLE
Fix cilium startup issues for openstack mode

### DIFF
--- a/pkg/ipam/allocator/openstack/openstack.go
+++ b/pkg/ipam/allocator/openstack/openstack.go
@@ -39,7 +39,7 @@ func (a *AllocatorOpenStack) Init(ctx context.Context) error {
 	var err error
 	networkID := operatorOption.Config.OpenStackNetworkID
 	if networkID == "" {
-			return err
+		return fmt.Errorf("faile to init openstack IPAM allocator, Network ID is required")
 	}
 
 	subnetID := operatorOption.Config.OpenStackSubnetID

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -724,7 +724,6 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 		nodeResource.Spec.InstanceID = nodeInfo.UUID
 		nodeResource.Spec.OpenStack.AvailabilityZone = nodeInfo.AvailabilityZone
 
-		log.Infof("####################### netconfig is %+v, openstack is %+v", n.NetConf, n.NetConf.OpenStack)
 		if c := n.NetConf; c != nil {
 			if len(c.OpenStack.SecurityGroups) > 0 {
 				nodeResource.Spec.OpenStack.SecurityGroups = c.OpenStack.SecurityGroups

--- a/pkg/openstack/api/api.go
+++ b/pkg/openstack/api/api.go
@@ -615,7 +615,9 @@ func (c *Client) describeNetworkInterfaces() ([]ports.Port, error) {
 func (c *Client) describeVpcs() ([]networks.Network, error) {
 	opts := networks.ListOpts{
 		ProjectID: c.filters[ProjectID],
+		ID: c.filters[NetworkID],
 	}
+
 	pages, _ := networks.List(c.neutronV2, opts).AllPages()
 	allNetworks, _ := networks.ExtractNetworks(pages)
 	return allNetworks, nil


### PR DESCRIPTION
-  for operator, networkid is required, projectid and subnetid are optional
-  for agent, networkid/projectid/subnetid are all optional
