### PR TITLE
redirectpolicy: prevent startup deadlock

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -625,7 +625,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 
 	d.svc = service.NewService(&d, d.l7Proxy, d.datapath.LBMap())
 
-	d.redirectPolicyManager = redirectpolicy.NewRedirectPolicyManager(d.svc)
+	d.redirectPolicyManager = redirectpolicy.NewRedirectPolicyManager(d.svc, params.Resources.LocalPods)
 	if option.Config.BGPAnnounceLBIP || option.Config.BGPAnnouncePodCIDR {
 		log.WithField("url", "https://github.com/cilium/cilium/issues/22246").
 			Warn("You are using the legacy BGP feature, which will only receive security updates and bugfixes. " +
@@ -685,7 +685,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	d.k8sWatcher.RegisterNodeSubscriber(watchers.NewCiliumNodeUpdater(d.nodeDiscovery))
 
 	d.redirectPolicyManager.RegisterSvcCache(d.k8sWatcher.K8sSvcCache)
-	d.redirectPolicyManager.RegisterGetStores(d.k8sWatcher)
 	if option.Config.BGPAnnounceLBIP {
 		d.bgpSpeaker.RegisterSvcCache(d.k8sWatcher.K8sSvcCache)
 	}


### PR DESCRIPTION
This commit prevents a deadlock in startup when local redirect policies are in use.

Involved in the deadlock is the node-local pod watcher and the redirectpolicy manager. The pod watcher (synchronously) calls into the manager, in oder to notify it of a pod event. The manager then tries to acquire a reference to the pod store. Due to recent refactoring, however, this leads to a wait cycle:

1. Acquiring the pod store reference blocks on initial synchronisation of the store, by waiting for the `podStoreSet` channel to be closed.
2. This channel is closed by the watcher once it receives a `Sync` event from the local pod resource. Before the resource emits a Sync event, however, it will 'replay' the consumer up to the current snapshot by emitting Upsert events.
3. In the Upsert call, the redirectpolicy manager is called (blocking on 1.), and we have a classical deadlock.

To fix this, instead of going through the k8s watcher to acquire a reference to the local pod store, inject the resource directly into the redirect policy manager. This will also block on the store being synchronised, but not by way of the `podStoreSet` channel (closed by the k8s watcher): it instead relies on the Resource[T]-internal tracking.

Fixes: 3db8b14a95 (k8s: Use LocalPodResource in pod watcher)