### PR TITLE
Avoid creating nic when assign ip failed

### DIFF
--- a/pkg/ipam/crd_multipool.go
+++ b/pkg/ipam/crd_multipool.go
@@ -296,6 +296,8 @@ func (p *crdPool) handleMultiPoolIPAllocation(ctx context.Context, a *maintenanc
 			"selectedInterface": a.allocation.InterfaceID,
 			"ipsToAllocate":     a.allocation.AvailableForAllocation,
 		}).WithError(err).Warning("Unable to assign additional IPs to interface, will create new interface")
+
+		return false, err
 	}
 
 	return p.node.createInterface(ctx, a.allocation, p.name)


### PR DESCRIPTION
官方在处理对网卡挂载辅助ip失败后，会走创建网卡步骤，而有的时候只是访问proton接口失败了，创建网卡并不能解决问题，反而会引起网卡配额的竞争，这里在处理挂载辅助ip失败后直接返回错误。