### PR TITLE
Release empty nics when releasing ips

### DIFF
--- a/pkg/alibabacloud/eni/node.go
+++ b/pkg/alibabacloud/eni/node.go
@@ -88,6 +88,10 @@ func (n *Node) ReleaseStaticIP(address string, pool string) error {
 	return errors.New("ReleaseStaticIP function for Alibaba ENI is not supported")
 }
 
+func (n *Node) DeleteInterface(ctx context.Context, scopedLog *logrus.Entry, enis []string, pool string) error {
+	return errors.New("ReleaseStaticIP function for Alibaba ENI is not supported")
+}
+
 // UpdatedNode is called when an update to the CiliumNode is received.
 func (n *Node) UpdatedNode(obj *v2.CiliumNode) {
 	n.mutex.Lock()

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -92,6 +92,10 @@ func (n *Node) ReleaseStaticIP(address string, pool string) error {
 	return errors.New("ReleaseStaticIP function for AWS ENI is not supported")
 }
 
+func (n *Node) DeleteInterface(ctx context.Context, scopedLog *logrus.Entry, enis []string, pool string) error {
+	return errors.New("ReleaseStaticIP function for AWS ENI is not supported")
+}
+
 // NewNode returns a new Node
 func NewNode(node *ipam.Node, k8sObj *v2.CiliumNode, manager *InstancesManager) *Node {
 	return &Node{

--- a/pkg/ipam/crd_multipool.go
+++ b/pkg/ipam/crd_multipool.go
@@ -315,7 +315,7 @@ func (p *crdPool) handleMultiPoolIPAllocation(ctx context.Context, a *maintenanc
 //
 // Handshake would be aborted if there are new allocations and the node doesn't have IPs in excess anymore.
 func (p *crdPool) handleIPRelease(ctx context.Context, a *maintenanceAction) (instanceMutated bool, err error) {
-	return p.node.handleIPRelease(ctx, a)
+	return p.node.handleIPRelease(ctx, a, string(p.name))
 }
 
 // abortNoLongerExcessIPs allows for aborting release of IP if new allocations on the node result in a change of excess

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -61,6 +61,9 @@ type NodeOperations interface {
 	// AllocationAction.MaxIPsToAllocate.
 	CreateInterface(ctx context.Context, allocation *AllocationAction, scopedLog *logrus.Entry, pool Pool) (int, string, error)
 
+	// DeleteInterface is called to delete interfaces
+	DeleteInterface(ctx context.Context, scopedLog *logrus.Entry, enis []string, pool string) error
+
 	// ResyncInterfacesAndIPs is called to synchronize the latest list of
 	// interfaces and IPs associated with the node. This function is called
 	// sparingly as this information is kept in sync based on the success

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -89,6 +89,11 @@ type nodeOperationsMock struct {
 	allocatedIPs []string
 }
 
+func (n *nodeOperationsMock) DeleteInterface(ctx context.Context, scopedLog *logrus.Entry, enis []string, pool string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (n *nodeOperationsMock) ResyncInterfacesAndIPsByPool(ctx context.Context, scopedLog *logrus.Entry) (poolAvailable map[Pool]ipamTypes.AllocationMap, stats ipamStats.InterfaceStats, err error) {
 	//TODO implement me
 	panic("implement me")
@@ -105,6 +110,11 @@ func (n *nodeOperationsMock) AllocateStaticIP(ctx context.Context, address strin
 }
 
 func (n *nodeOperationsMock) UnbindStaticIP(ctx context.Context, address string, pool string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (n *Node) DeleteInterface(ctx context.Context, scopedLog *logrus.Entry, enis []string, pool string) error {
 	//TODO implement me
 	panic("implement me")
 }


### PR DESCRIPTION
该pr新增了在releaseIPs方法中对空网卡（没有挂载辅助ip的网卡）的处理。注意：空网卡不会主动释放，只会在释放辅助ip的时候一并计算且释放。